### PR TITLE
Release workflow only when icons added

### DIFF
--- a/.github/workflows/icons-release.yml
+++ b/.github/workflows/icons-release.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
   workflow_dispatch:
+  push:
+    paths:
+      - "icons/"
 
 jobs:
   build:


### PR DESCRIPTION
Previously, our release workflow would trigger on any closed pull request or manual trigger, regardless of whether any new icons were added. This could result in unnecessary and unhelpful releases being made.

This pull request adds a new trigger to the release workflow, so that it will only be triggered when a push is made to the "icons/" directory. This ensures that a release will only be made when new icons have been added, which is the main purpose of this workflow.

Overall, this change will improve the efficiency of our release workflow by ensuring that releases are only made when they are actually necessary.