### PR TITLE
Rule for avoid evenodd icons

### DIFF
--- a/.github/workflows/figma-export copy.yml
+++ b/.github/workflows/figma-export copy.yml
@@ -21,7 +21,7 @@ jobs:
           files_with_evenodd=""
           for file in $(find icons -name "*.svg"); do
             if grep -q "evenodd" "$file"; then
-              echo "Se encontró la palabra 'evenodd' en $file"
+              # echo "Se encontró la palabra 'evenodd' en $file"
               files_with_evenodd="${files_with_evenodd}${file}\n"
             fi
           done

--- a/.github/workflows/figma-export copy.yml
+++ b/.github/workflows/figma-export copy.yml
@@ -3,10 +3,10 @@ name: Buscar palabra en archivos SVG
 on:
   push:
     branches:
-      - main
+      - production
   pull_request:
     branches:
-      - main
+      - production
 
 jobs:
   build:

--- a/.github/workflows/figma-export copy.yml
+++ b/.github/workflows/figma-export copy.yml
@@ -1,4 +1,4 @@
-name: Buscar palabra en archivos SVG
+name: Search & Destroy evenodds
 
 on:
   push:

--- a/.github/workflows/figma-export copy.yml
+++ b/.github/workflows/figma-export copy.yml
@@ -1,0 +1,31 @@
+name: Buscar palabra en archivos SVG
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout del repositorio
+        uses: actions/checkout@v2
+
+      - name: Buscar palabra en archivos SVG
+        run: |
+          files_with_evenodd=""
+          for file in $(find icons -name "*.svg"); do
+            if grep -q "evenodd" "$file"; then
+              echo "Se encontró la palabra 'evenodd' en $file"
+              files_with_evenodd="${files_with_evenodd}${file}\n"
+            fi
+          done
+          if [ -n "$files_with_evenodd" ]; then
+            echo -e "Archivos con 'evenodd':\n${files_with_evenodd}"
+            exit 1
+          fi


### PR DESCRIPTION
Adds a new rule to our Figma export workflow. The new rule searches for the word 'evenodd' in SVG files and fails the build if any file contains it. The use of 'evenodd' in SVG files can cause issues with rendering and accessibility, and it is best practice to avoid it.

By adding this rule to our workflow, we ensure that our SVG files are compliant with best practices and avoid potential issues with rendering and accessibility. This will improve the overall quality of our project and prevent potential issues from arising in the future.

Overall, this change improves the project by ensuring that our SVG files are compliant with best practices and avoiding potential issues with rendering and accessibility.