### PR TITLE
Aramo chage file key

### DIFF
--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -30,11 +30,11 @@ env:
   O2_NEW_FIGMA_ID: CjvgrHEIycSQ6exznxnFXT
   BLAU_FIGMA_ID: czemeClWRGBI8oF7caNa5m
   VIVO_FIGMA_ID: EApRpjaTyUOwW5VQU2ZqgP
-  MISTICA_ICONS_FILE_URL: https://www.figma.com/design/JXy7Y07eb0Axg0ThVRWKju/Default-Icons-Set?node-id=0-71&node-type=canvas&t=7CTmVGq8V3eDnoFX-0
+  MISTICA_ICONS_FILE_URL: https://www.figma.com/design/JXy7Y07eb0Axg0ThVRWKju/Default-Icons-Set?node-id=0-71&t=1nybaZ1fzHqRq80C-1
   O2_FILE_URL: https://www.figma.com/file/wHTqJ7KDhGKrNSNpmMb9nW/?node-id=611%3A3298
-  O2_NEW_FILE_URL: https://www.figma.com/design/CjvgrHEIycSQ6exznxnFXT/O2-(Variables)?node-id=4-0&node-type=canvas&t=J3HiShznnDyFkMrm-0
-  BLAU_FILE_URL: https://www.figma.com/design/czemeClWRGBI8oF7caNa5m/Blau-(Variables)?node-id=0-1&t=hPYGbaGdrBGfuy8S-1
-  VIVO_FILE_URL: https://www.figma.com/design/EApRpjaTyUOwW5VQU2ZqgP/Vivo-(Variables)?node-id=4-0&node-type=canvas&t=du7a3ZgfuPiKoXog-0
+  O2_NEW_FILE_URL: https://www.figma.com/design/CjvgrHEIycSQ6exznxnFXT/O2?m=auto&node-id=4-0&t=0HBFuR3VADUhh5Zr-1
+  BLAU_FILE_URL: https://www.figma.com/design/czemeClWRGBI8oF7caNa5m/Blau?node-id=0-1&node-type=canvas&t=CM2TIEBRzYVgRX5A-0
+  VIVO_FILE_URL: https://www.figma.com/design/EApRpjaTyUOwW5VQU2ZqgP/Vivo?node-id=4-0&node-type=canvas&t=pnjxXOX7B7hd3BmJ-0
 
 jobs:
   export-all:

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -25,16 +25,16 @@ on:
         description: Draft PR
 
 env:
-  TELEFONICA_FIGMA_ID: JHuzksh01yxExMeMQBvymq
+  TELEFONICA_FIGMA_ID: JXy7Y07eb0Axg0ThVRWKju
   O2_FIGMA_ID: wHTqJ7KDhGKrNSNpmMb9nW
-  O2_NEW_FIGMA_ID: M9q1Iu9zuoQtoIktd915gj
-  BLAU_FIGMA_ID: 6TYIfq6EZJl7NcSbbYAo79
-  VIVO_FIGMA_ID: IrcHGIgsF5Cq4ZX1LRhuis
-  MISTICA_ICONS_FILE_URL: https://www.figma.com/file/JHuzksh01yxExMeMQBvymq/M%C3%ADstica-Icons?node-id=0%3A71&t=hqGKHvCEvRHET7YC-0
+  O2_NEW_FIGMA_ID: CjvgrHEIycSQ6exznxnFXT
+  BLAU_FIGMA_ID: czemeClWRGBI8oF7caNa5m
+  VIVO_FIGMA_ID: EApRpjaTyUOwW5VQU2ZqgP
+  MISTICA_ICONS_FILE_URL: https://www.figma.com/design/JXy7Y07eb0Axg0ThVRWKju/Default-Icons-Set?node-id=0-71&node-type=canvas&t=7CTmVGq8V3eDnoFX-0
   O2_FILE_URL: https://www.figma.com/file/wHTqJ7KDhGKrNSNpmMb9nW/?node-id=611%3A3298
-  O2_NEW_FILE_URL: https://www.figma.com/design/M9q1Iu9zuoQtoIktd915gj/O2-New?node-id=3962-2&t=ute0n3XeLMeJ2cUO-0
-  BLAU_FILE_URL: https://www.figma.com/file/6TYIfq6EZJl7NcSbbYAo79/Blau?node-id=0%3A1
-  VIVO_FILE_URL: https://www.figma.com/file/IrcHGIgsF5Cq4ZX1LRhuis/Vivo-New-(Beta)?type=design&node-id=2625-199
+  O2_NEW_FILE_URL: https://www.figma.com/design/CjvgrHEIycSQ6exznxnFXT/O2-(Variables)?node-id=4-0&node-type=canvas&t=J3HiShznnDyFkMrm-0
+  BLAU_FILE_URL: https://www.figma.com/design/czemeClWRGBI8oF7caNa5m/Blau-(Variables)?node-id=0-1&t=hPYGbaGdrBGfuy8S-1
+  VIVO_FILE_URL: https://www.figma.com/design/EApRpjaTyUOwW5VQU2ZqgP/Vivo-(Variables)?node-id=4-0&node-type=canvas&t=du7a3ZgfuPiKoXog-0
 
 jobs:
   export-all:


### PR DESCRIPTION
### Pull Request Description: Aramo Change File Key

This pull request updates the Figma file IDs and URLs used in the GitHub Actions workflow for Figma exports. The motivation behind these changes is to ensure that the workflow points to the latest design files and resources, which have been updated in Figma.

**Key Changes:**
- Updated the `TELEFONICA_FIGMA_ID` to reflect the new identifier.
- Modified the `O2_NEW_FIGMA_ID`, `BLAU_FIGMA_ID`, and `VIVO_FIGMA_ID` to their new corresponding values.
- Updated the URLs for `MISTICA_ICONS_FILE_URL`, `O2_NEW_FILE_URL`, `BLAU_FILE_URL`, and `VIVO_FILE_URL` to direct to the latest designs.

**Why This Improves the Project:**
By ensuring that our workflow is aligned with the latest design updates, we enhance our ability to automate exports accurately. This prevents potential discrepancies between the designs and the exported assets, fostering a more efficient development process. Keeping our design references up to date is crucial for maintaining the quality and consistency of our project outputs.