### PR TITLE
Fix export icons workflow

### DIFF
--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -101,12 +101,19 @@ jobs:
 
       - name: Convert to PDF
         run: |
-          sudo apt-get update && sudo apt-get install -y mat2
-          for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id --linearize $i; done # remove PDF metadata
+          sudo apt-get update && sudo apt-get install -y mat2 librsvg2-bin exiftool qpdf
+          # Convert SVG files to PDF
+          for i in $(find icons -type f -name "*.svg"); do
+            rsvg-convert -f pdf -o "${i%.*}.pdf" "$i"
+          done
+
+          # Remove metadata from PDFs and optimize them
+          for file in $(find icons -type f -name "*.pdf"); do
             echo "$file"
             exiftool -overwrite_original_in_place -all:all= "$file" > /dev/null 2>&1
+            qpdf --replace-input --deterministic-id --linearize "$file"
           done
+
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           npm install figma-export-icons --save
           sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
-
       - name: Checkout branch or create new one
         run: |
           git fetch
@@ -59,7 +58,6 @@ jobs:
           else
               git checkout -b import-figma-icons
           fi
-
       - name: Generate icon config
         run: |
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.TELEFONICA_FIGMA_ID}}/' -e 's/ICON_FRAME/Filled/' -e 's|ICON_PATH|icons/telefonica/filled|g' figma-export-icons.template.json > telefonica-filled.json
@@ -76,7 +74,6 @@ jobs:
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.VIVO_FIGMA_ID}}/' -e 's/ICON_FRAME/Filled/' -e 's|ICON_PATH|icons/vivo-new/filled|g' figma-export-icons.template.json > vivo-filled.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.VIVO_FIGMA_ID}}/' -e 's/ICON_FRAME/Regular/' -e 's|ICON_PATH|icons/vivo-new/regular|g' figma-export-icons.template.json > vivo-regular.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.VIVO_FIGMA_ID}}/' -e 's/ICON_FRAME/Light/' -e 's|ICON_PATH|icons/vivo-new/light|g' figma-export-icons.template.json > vivo-light.json
-
       - name: Export icons
         run: |
           npm run export-telefonica-filled
@@ -93,18 +90,18 @@ jobs:
           npm run export-vivo-filled
           npm run export-vivo-regular
           npm run export-vivo-light
-
       - name: Install SVGO & convert
         run: |
           yarn global add svgo
           svgo -f icons -r -o icons
-
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
-
+          find icons -type f -name "*.pdf" | while IFS= read -r file; do
+            echo "$file"
+            exiftool -overwrite_original_in_place -all:all= "$file" > /dev/null 2>&1
+          done
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
@@ -117,7 +114,6 @@ jobs:
           git add .
           git commit -m "Figma icons updated"
           git push origin import-figma-icons
-
       - name: Create Pull-Request
         uses: repo-sync/pull-request@v2
         with:
@@ -143,7 +139,6 @@ jobs:
         run: |
           npm install figma-export-icons --save
           sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
-
       - name: Checkout branch or create new one
         run: |
           git fetch
@@ -152,30 +147,25 @@ jobs:
           else
               git checkout -b import-figma-icons
           fi
-
       - name: Generate icon config
         run: |
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.TELEFONICA_FIGMA_ID}}/' -e 's/ICON_FRAME/Filled/' -e 's|ICON_PATH|icons/telefonica/filled|g' figma-export-icons.template.json > telefonica-filled.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.TELEFONICA_FIGMA_ID}}/' -e 's/ICON_FRAME/Regular/' -e 's|ICON_PATH|icons/telefonica/regular|g' figma-export-icons.template.json > telefonica-regular.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.TELEFONICA_FIGMA_ID}}/' -e 's/ICON_FRAME/Light/' -e 's|ICON_PATH|icons/telefonica/light|g' figma-export-icons.template.json > telefonica-light.json
-
       - name: Export icons
         run: |
           npm run export-telefonica-filled
           npm run export-telefonica-regular
           npm run export-telefonica-light
-
       - name: Install SVGO & convert
         run: |
           yarn global add svgo
           svgo -f icons/telefonica -r -o icons/telefonica
-
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons/telefonica -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
           for i in $(find icons/telefonica -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
-
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
@@ -188,7 +178,6 @@ jobs:
           git add .
           git commit -m "Figma icons updated"
           git push origin import-figma-icons
-
       - name: Create Pull-Request
         uses: repo-sync/pull-request@v2
         with:
@@ -214,7 +203,6 @@ jobs:
         run: |
           npm install figma-export-icons --save
           sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
-
       - name: Checkout branch or create new one
         run: |
           git fetch
@@ -223,30 +211,25 @@ jobs:
           else
               git checkout -b import-figma-icons
           fi
-
       - name: Generate icon config
         run: |
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.O2_FIGMA_ID}}/' -e 's/ICON_FRAME/Filled/' -e 's|ICON_PATH|icons/o2/filled|g' figma-export-icons.template.json > o2-filled.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.O2_FIGMA_ID}}/' -e 's/ICON_FRAME/Regular/' -e 's|ICON_PATH|icons/o2/regular|g' figma-export-icons.template.json > o2-regular.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.O2_FIGMA_ID}}/' -e 's/ICON_FRAME/Light/' -e 's|ICON_PATH|icons/o2/light|g' figma-export-icons.template.json > o2-light.json
-
       - name: Export icons
         run: |
           npm run export-o2-filled
           npm run export-o2-regular
           npm run export-o2-light
-
       - name: Install SVGO & convert
         run: |
           yarn global add svgo
           svgo -f icons/o2 -r -o icons/o2
-
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons/o2 -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
           for i in $(find icons/o2 -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
-
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
@@ -259,7 +242,6 @@ jobs:
           git add .
           git commit -m "Figma icons updated"
           git push origin import-figma-icons
-
       - name: Create Pull-Request
         uses: repo-sync/pull-request@v2
         with:
@@ -285,7 +267,6 @@ jobs:
         run: |
           npm install figma-export-icons --save
           sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
-
       - name: Checkout branch or create new one
         run: |
           git fetch
@@ -294,33 +275,25 @@ jobs:
           else
               git checkout -b import-figma-icons
           fi
-
       - name: Generate icon config
         run: |
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.O2_NEW_FIGMA_ID}}/' -e 's/ICON_FRAME/Filled/' -e 's|ICON_PATH|icons/o2-new/filled|g' figma-export-icons.template.json > o2-new-filled.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.O2_NEW_FIGMA_ID}}/' -e 's/ICON_FRAME/Regular/' -e 's|ICON_PATH|icons/o2-new/regular|g' figma-export-icons.template.json > o2-new-regular.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.O2_NEW_FIGMA_ID}}/' -e 's/ICON_FRAME/Light/' -e 's|ICON_PATH|icons/o2-new/light|g' figma-export-icons.template.json > o2-new-light.json
-
       - name: Export icons
         run: |
           npm run export-o2-new-filled
           npm run export-o2-new-regular
           npm run export-o2-new-light
-
       - name: Install SVGO & convert
         run: |
           yarn global add svgo
           svgo -f icons/o2-new -r -o icons/o2-new
-
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
-          for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          find icons -type f -name "*.pdf" | while IFS= read -r file; do
-            echo "$file"
-            exiftool -overwrite_original_in_place -all:all= "$file" > /dev/null 2>&1
-          done
-
+          for i in $(find icons/o2-new -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
+          for i in $(find icons/o2-new -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
@@ -333,7 +306,6 @@ jobs:
           git add .
           git commit -m "Figma icons updated"
           git push origin import-figma-icons
-
       - name: Create Pull-Request
         uses: repo-sync/pull-request@v2
         with:
@@ -359,7 +331,6 @@ jobs:
         run: |
           npm install figma-export-icons --save
           sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
-
       - name: Checkout branch or create new one
         run: |
           git fetch
@@ -368,28 +339,23 @@ jobs:
           else
               git checkout -b import-figma-icons
           fi
-
       - name: Generate icon config
         run: |
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.BLAU_FIGMA_ID}}/' -e 's/ICON_FRAME/Regular/' -e 's|ICON_PATH|icons/blau/regular|g' figma-export-icons.template.json > blau-regular.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.BLAU_FIGMA_ID}}/' -e 's/ICON_FRAME/Filled/' -e 's|ICON_PATH|icons/blau/filled|g' figma-export-icons.template.json > blau-filled.json
-
       - name: Export icons
         run: |
           npm run export-blau-regular
           npm run export-blau-filled
-
       - name: Install SVGO & convert
         run: |
           yarn global add svgo
           svgo -f icons/blau -r -o icons/blau
-
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons/blau -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
           for i in $(find icons/blau -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
-
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
@@ -402,7 +368,6 @@ jobs:
           git add .
           git commit -m "Figma icons updated"
           git push origin import-figma-icons
-
       - name: Create Pull-Request
         uses: repo-sync/pull-request@v2
         with:
@@ -428,7 +393,6 @@ jobs:
         run: |
           npm install figma-export-icons --save
           sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
-
       - name: Checkout branch or create new one
         run: |
           git fetch
@@ -437,30 +401,25 @@ jobs:
           else
               git checkout -b import-figma-icons
           fi
-
       - name: Generate icon config
         run: |
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.VIVO_FIGMA_ID}}/' -e 's/ICON_FRAME/Filled/' -e 's|ICON_PATH|icons/vivo-new/filled|g' figma-export-icons.template.json > vivo-filled.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.VIVO_FIGMA_ID}}/' -e 's/ICON_FRAME/Regular/' -e 's|ICON_PATH|icons/vivo-new/regular|g' figma-export-icons.template.json > vivo-regular.json
           sed -e 's/YOUR_PERSONAL_TOKEN/${{secrets.FIGMA_TOKEN}}/' -e 's/FILE_ID/${{env.VIVO_FIGMA_ID}}/' -e 's/ICON_FRAME/Light/' -e 's|ICON_PATH|icons/vivo-new/light|g' figma-export-icons.template.json > vivo-light.json
-
       - name: Export icons
         run: |
           npm run export-vivo-filled
           npm run export-vivo-regular
           npm run export-vivo-light
-
       - name: Install SVGO & convert
         run: |
           yarn global add svgo
           svgo -f icons/vivo-new -r -o icons/vivo-new
-
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons/vivo-new -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
           for i in $(find icons/vivo-new -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
-
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
@@ -473,7 +432,6 @@ jobs:
           git add .
           git commit -m "Figma icons updated"
           git push origin import-figma-icons
-
       - name: Create Pull-Request
         uses: repo-sync/pull-request@v2
         with:
@@ -492,4 +450,3 @@ jobs:
 #             [mistica-icons]: https://www.figma.com/file/${{env.TELEFONICA_FIGMA_ID}}/Mistica'-Icons?node-id=0%3A71 n\
 #             [o2-icons]: https://www.figma.com/file/${{env.O2_FIGMA_ID}}/?node-id=611%3A3298 n\
 #             [readme]: https://github.com/Telefonica/mistica-icons/tree/import-figma-icons"
-

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          npm install figma-export-icons --save
           sudo apt-get update
           sudo apt-get install -y \
             librsvg2-bin \

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --fix-xref --deterministic-id $i; done # remove PDF metadata
+          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
 
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install packages
         run: |
           npm install figma-export-icons --save
-          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
+          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf=11.8.0
 
       - name: Checkout branch or create new one
         run: |
@@ -94,16 +94,16 @@ jobs:
           npm run export-vivo-regular
           npm run export-vivo-light
 
+      - name: Install SVGO & convert
+        run: |
+          yarn global add svgo
+          svgo -f icons -r -o icons
+
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
           for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
-
-      - name: Install SVGO & convert
-        run: |
-          yarn global add svgo
-          svgo -f icons -r -o icons
 
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install packages
         run: |
           npm install figma-export-icons --save
-          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf=11.8.0
+          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
 
       - name: Checkout branch or create new one
         run: |
@@ -103,7 +103,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
+          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --fix-xref --deterministic-id $i; done # remove PDF metadata
 
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -51,6 +51,11 @@ jobs:
           npm install figma-export-icons --save
           sudo apt-get install -y librsvg2-bin libimage-exiftool-perl wget tar cmake make g++ npm yarn
 
+      - name: Install required libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjpeg-dev libgnutls28-dev
+
       - name: Install qpdf 11.8.0
         run: |
           wget https://github.com/qpdf/qpdf/releases/download/v11.8.0/qpdf-11.8.0.tar.gz

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          find icons -type f -name "*.pdf" | while IFS= read -r file; do
+          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id --linearize $i; done # remove PDF metadata
             echo "$file"
             exiftool -overwrite_original_in_place -all:all= "$file" > /dev/null 2>&1
           done

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -49,7 +49,18 @@ jobs:
       - name: Install packages
         run: |
           npm install figma-export-icons --save
-          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
+          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl wget tar cmake make g++ npm yarn
+
+      - name: Install qpdf 11.8.0
+        run: |
+          wget https://github.com/qpdf/qpdf/releases/download/release-qpdf-11.8.0/qpdf-11.8.0.tar.gz
+          tar -xzf qpdf-11.8.0.tar.gz
+          cd qpdf-11.8.0
+          mkdir build && cd build
+          cmake ..
+          make
+          sudo make install
+          qpdf --version
 
       - name: Checkout branch or create new one
         run: |

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -94,25 +94,16 @@ jobs:
           npm run export-vivo-regular
           npm run export-vivo-light
 
+      - name: Convert to PDF
+        run: |
+          sudo apt-get update && sudo apt-get install -y mat2
+          for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
+          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
+
       - name: Install SVGO & convert
         run: |
           yarn global add svgo
           svgo -f icons -r -o icons
-
-      - name: Convert to PDF
-        run: |
-          sudo apt-get update && sudo apt-get install -y mat2 librsvg2-bin exiftool qpdf
-          # Convert SVG files to PDF
-          for i in $(find icons -type f -name "*.svg"); do
-            rsvg-convert -f pdf -o "${i%.*}.pdf" "$i"
-          done
-
-          # Remove metadata from PDFs and optimize them
-          for file in $(find icons -type f -name "*.pdf"); do
-            echo "$file"
-            exiftool -overwrite_original_in_place -all:all= "$file" > /dev/null 2>&1
-            qpdf --replace-input --deterministic-id --linearize "$file"
-          done
 
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -46,15 +46,21 @@ jobs:
       # - name: Get branch name
       #   uses: rlespinasse/github-slug-action@v3.x
 
-      - name: Install packages
-        run: |
-          npm install figma-export-icons --save
-          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl wget tar cmake make g++ npm yarn
-
-      - name: Install required libraries
+      - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libjpeg-dev libgnutls28-dev
+          sudo apt-get install -y \
+            librsvg2-bin \
+            libimage-exiftool-perl \
+            wget \
+            tar \
+            cmake \
+            make \
+            g++ \
+            libjpeg-dev \
+            libgnutls28-dev \
+            npm \
+            yarn
 
       - name: Install qpdf 11.8.0
         run: |
@@ -65,6 +71,8 @@ jobs:
           cmake ..
           make
           sudo make install
+          echo "/usr/local/lib" | sudo tee -a /etc/ld.so.conf.d/qpdf.conf
+          sudo ldconfig
           qpdf --version
 
       - name: Checkout branch or create new one

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -46,35 +46,10 @@ jobs:
       # - name: Get branch name
       #   uses: rlespinasse/github-slug-action@v3.x
 
-      - name: Install dependencies
+      - name: Install packages
         run: |
           npm install figma-export-icons --save
-          sudo apt-get update
-          sudo apt-get install -y \
-            librsvg2-bin \
-            libimage-exiftool-perl \
-            wget \
-            tar \
-            cmake \
-            make \
-            g++ \
-            libjpeg-dev \
-            libgnutls28-dev \
-            npm \
-            yarn
-
-      - name: Install qpdf 11.8.0
-        run: |
-          wget https://github.com/qpdf/qpdf/releases/download/v11.8.0/qpdf-11.8.0.tar.gz
-          tar -xzf qpdf-11.8.0.tar.gz
-          cd qpdf-11.8.0
-          mkdir build && cd build
-          cmake ..
-          make
-          sudo make install
-          echo "/usr/local/lib" | sudo tee -a /etc/ld.so.conf.d/qpdf.conf
-          sudo ldconfig
-          qpdf --version
+          sudo apt-get install -y librsvg2-bin libimage-exiftool-perl qpdf
 
       - name: Checkout branch or create new one
         run: |
@@ -339,9 +314,39 @@ jobs:
 
       - name: Convert to PDF
         run: |
+          echo "Starting conversion of SVG files to PDF..."
           sudo apt-get update && sudo apt-get install -y mat2
-          for i in $(find icons/o2-new -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          for i in $(find icons/o2-new -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
+          echo "Installed mat2 for metadata removal."
+
+          echo "Converting SVG files to PDF:"
+          find icons -type f -name "*.svg" | while read -r svg_file; do
+            pdf_file="${svg_file%.*}.pdf"
+            echo "Converting $svg_file to $pdf_file..."
+            if rsvg-convert -f pdf -o "$pdf_file" "$svg_file"; then
+              echo "Successfully converted $svg_file to $pdf_file."
+            else
+              echo "ERROR: Failed to convert $svg_file to $pdf_file." >&2
+            fi
+          done
+
+          echo "Removing metadata from PDF files:"
+          find icons -type f -name "*.pdf" | while read -r pdf_file; do
+            echo "Processing $pdf_file..."
+            if exiftool -overwrite_original_in_place -all:all= "$pdf_file" > /dev/null 2>&1; then
+              echo "Metadata successfully removed from $pdf_file."
+            else
+              echo "ERROR: Failed to remove metadata from $pdf_file." >&2
+            fi
+
+            echo "Optimizing $pdf_file with QPDF..."
+            if qpdf --replace-input --deterministic-id "$pdf_file"; then
+              echo "Successfully optimized $pdf_file with QPDF."
+            else
+              echo "ERROR: Failed to optimize $pdf_file with QPDF." >&2
+            fi
+          done
+
+          echo "SVG to PDF conversion and metadata cleanup complete."
 
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -314,39 +314,12 @@ jobs:
 
       - name: Convert to PDF
         run: |
-          echo "Starting conversion of SVG files to PDF..."
           sudo apt-get update && sudo apt-get install -y mat2
-          echo "Installed mat2 for metadata removal."
-
-          echo "Converting SVG files to PDF:"
-          find icons -type f -name "*.svg" | while read -r svg_file; do
-            pdf_file="${svg_file%.*}.pdf"
-            echo "Converting $svg_file to $pdf_file..."
-            if rsvg-convert -f pdf -o "$pdf_file" "$svg_file"; then
-              echo "Successfully converted $svg_file to $pdf_file."
-            else
-              echo "ERROR: Failed to convert $svg_file to $pdf_file." >&2
-            fi
+          for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
+          find icons -type f -name "*.pdf" | while IFS= read -r file; do
+            echo "$file"
+            exiftool -overwrite_original_in_place -all:all= "$file" > /dev/null 2>&1
           done
-
-          echo "Removing metadata from PDF files:"
-          find icons -type f -name "*.pdf" | while read -r pdf_file; do
-            echo "Processing $pdf_file..."
-            if exiftool -overwrite_original_in_place -all:all= "$pdf_file" > /dev/null 2>&1; then
-              echo "Metadata successfully removed from $pdf_file."
-            else
-              echo "ERROR: Failed to remove metadata from $pdf_file." >&2
-            fi
-
-            echo "Optimizing $pdf_file with QPDF..."
-            if qpdf --replace-input --deterministic-id "$pdf_file"; then
-              echo "Successfully optimized $pdf_file with QPDF."
-            else
-              echo "ERROR: Failed to optimize $pdf_file with QPDF." >&2
-            fi
-          done
-
-          echo "SVG to PDF conversion and metadata cleanup complete."
 
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -102,19 +102,10 @@ jobs:
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
-
-          for pdf in $(find icons -type f -name "*.pdf"); do
-              echo "Repairing $pdf"
-              gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile="$pdf" "$pdf" || echo "Failed to repair $pdf"
-          done
-
-          for pdf in $(find icons -type f -name "*.pdf"); do
-              echo "Processing $pdf"
-              exiftool -overwrite_original_in_place -all:all= "$pdf" > /dev/null 2>&1 || echo "Exiftool failed for $pdf"
-              qpdf --replace-input --deterministic-id "$pdf" || echo "QPDF failed for $pdf"
-          done
-
-      - name: Readme generator
+          for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
+          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1; done
+      
+          - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
       - name: Commit & Push

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -103,9 +103,11 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
           for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1; done
-      
-          - name: Readme generator
+          find icons -type f -name "*.pdf" | while IFS= read -r file; do
+            echo "$file"
+            exiftool -overwrite_original_in_place -all:all= "$file" > /dev/null 2>&1
+          done
+      - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons
 
       - name: Commit & Push

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -102,8 +102,17 @@ jobs:
       - name: Convert to PDF
         run: |
           sudo apt-get update && sudo apt-get install -y mat2
-          for i in $(find icons -type f -name "*.svg"); do rsvg-convert -f pdf -o ${i%.*}.pdf $i; done
-          for i in $(find icons -type f -name "*.pdf"); do echo $i && exiftool -overwrite_original_in_place -all:all= $i > /dev/null 2>&1 && qpdf --replace-input --deterministic-id $i; done # remove PDF metadata
+
+          for pdf in $(find icons -type f -name "*.pdf"); do
+              echo "Repairing $pdf"
+              gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile="$pdf" "$pdf" || echo "Failed to repair $pdf"
+          done
+
+          for pdf in $(find icons -type f -name "*.pdf"); do
+              echo "Processing $pdf"
+              exiftool -overwrite_original_in_place -all:all= "$pdf" > /dev/null 2>&1 || echo "Exiftool failed for $pdf"
+              qpdf --replace-input --deterministic-id "$pdf" || echo "QPDF failed for $pdf"
+          done
 
       - name: Readme generator
         run: sudo python3 .github/md-generator/generate_markdown.py icons

--- a/.github/workflows/figma-export.yml
+++ b/.github/workflows/figma-export.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install qpdf 11.8.0
         run: |
-          wget https://github.com/qpdf/qpdf/releases/download/release-qpdf-11.8.0/qpdf-11.8.0.tar.gz
+          wget https://github.com/qpdf/qpdf/releases/download/v11.8.0/qpdf-11.8.0.tar.gz
           tar -xzf qpdf-11.8.0.tar.gz
           cd qpdf-11.8.0
           mkdir build && cd build

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "figma-export-icons": "^1.5.0",
-    "kactus-cli": "^0.6.1"
+    "figma-export-icons": "^1.5.0"
   }
 }


### PR DESCRIPTION
I remove `qpdf --replace-input --deterministic-id $i` line because is generating PDFs errors by some reason.

That line that I removed helped to avoid generating many changes in the PRs when exporting the pdfs. This PR is a quick fix but it's probably that we will have 3K of changes in the next PR. (All pdf files generated again and overwritten)

Error in workflow
```
icons/o2/regular/football-ball-regular.pdf
WARNING: icons/o2/regular/football-ball-regular.pdf: object 10/0 has unexpected xref entry type
qpdf: there are warnings; original file kept in icons/o2/regular/football-ball-regular.pdf.~qpdf-orig
qpdf: operation succeeded with warnings; resulting file may have some problems
Error: Process completed with exit code 3.
```


Old pdf in repo:
```
yayo@Yayos-iMac icons % qpdf --check --show-xref o2/regular/football-ball-regular.pdf
checking o2/regular/football-ball-regular.pdf
PDF Version: 1.5
File is not encrypted
File is not linearized
No syntax or stream encoding errors found; the file may still contain
errors that qpdf cannot detect
1/0: uncompressed; offset = 15
2/0: uncompressed; offset = 64
3/0: uncompressed; offset = 123
4/0: uncompressed; offset = 293
5/0: uncompressed; offset = 961
```

Same pdf exported from Figma
```
yayo@Yayos-iMac icons % qpdf --check --show-xref o2/regular/football-ball-regular.pdf
checking o2/regular/football-ball-regular.pdf
PDF Version: 1.7
File is not encrypted
File is not linearized
No syntax or stream encoding errors found; the file may still contain
errors that qpdf cannot detect
1/0: uncompressed; offset = 10
2/0: uncompressed; offset = 2697
3/0: uncompressed; offset = 2720
4/0: uncompressed; offset = 2758
5/0: uncompressed; offset = 2810
6/0: uncompressed; offset = 3859
7/0: uncompressed; offset = 3881
8/0: uncompressed; offset = 4054
9/0: uncompressed; offset = 4128
```

