### PR TITLE
improve icons calculation

### DIFF
--- a/.github/md-generator/generate_markdown.py
+++ b/.github/md-generator/generate_markdown.py
@@ -98,7 +98,9 @@ def process_icon_sets(folders, all_concepts):
             if other_folder != folder:
                 data[folder]["some_equivalence"].update(current_no_processed_names & data[other_folder]["no_processed_names"])
         data[folder]["some_equivalence"] -= data[folder]["all_equivalence"]
-        data[folder]["missing"] = all_concepts - (data[folder]["unique"] | data[folder]["all_equivalence"] | data[folder]["some_equivalence"])
+        # Calculate missing icons correctly: icons present in other sets but not in current set
+        other_sets_icons = set.union(*(data[f]["no_processed_names"] for f in folders if f != folder))
+        data[folder]["missing"] = other_sets_icons - data[folder]["no_processed_names"]
 
     return data
 
@@ -116,26 +118,33 @@ def generate_bar_representation(data, folders, bar_width=400, bar_height=8):
         unique_count = len(folder_data['unique'])
         missing_count = len(folder_data['missing'])
         
+        # Calculate percentages based on total_icons (global total) for consistency
         all_equivalence_percent = (all_equivalence_count * 100) / total_icons
         some_equivalence_percent = (some_equivalence_count * 100) / total_icons
         unique_percent = (unique_count * 100) / total_icons
         missing_percent = (missing_count * 100) / total_icons
 
-        all_equivalence_width = round(int((all_equivalence_percent / 100) * bar_width))
-        if 0 < all_equivalence_percent < 1:
-            all_equivalence_width = 1
-
-        some_equivalence_width = round(int((some_equivalence_percent / 100) * bar_width))
-        if 0 < some_equivalence_percent < 1:
-            some_equivalence_width = 1
-
-        unique_width = round(int((unique_percent / 100) * bar_width))
-        if 0 < unique_percent < 1:
-            unique_width = 1
+        # Calculate bar widths proportionally to ensure total width equals bar_width
+        total_count = all_equivalence_count + some_equivalence_count + unique_count + missing_count
+        
+        if total_count > 0:
+            all_equivalence_width = round((all_equivalence_count / total_count) * bar_width)
+            some_equivalence_width = round((some_equivalence_count / total_count) * bar_width)
+            unique_width = round((unique_count / total_count) * bar_width)
+            # Ensure total width doesn't exceed bar_width due to rounding
+            missing_width = bar_width - (all_equivalence_width + some_equivalence_width + unique_width)
             
-        missing_width = bar_width - (unique_width + all_equivalence_width + some_equivalence_width)
-        if 0 < missing_percent < 1:
-            missing_width = 1
+            # Handle minimum width for very small percentages
+            if 0 < all_equivalence_percent < 1 and all_equivalence_width == 0:
+                all_equivalence_width = 1
+            if 0 < some_equivalence_percent < 1 and some_equivalence_width == 0:
+                some_equivalence_width = 1
+            if 0 < unique_percent < 1 and unique_width == 0:
+                unique_width = 1
+            if 0 < missing_percent < 1 and missing_width == 0:
+                missing_width = 1
+        else:
+            all_equivalence_width = some_equivalence_width = unique_width = missing_width = 0
         
         bar_parts = []
         if all_equivalence_width > 0:
@@ -171,14 +180,9 @@ def generate_markdown_table(data, folders):
         unique_count = len(folder_data['unique'])
         unique_percent = f"{unique_count} ({unique_count * 100 / total_icons:.1f}%) ![Unique](https://dummyimage.com/4x12/{bar_colors['unique']}/000&text=+)" if total_icons > 0 else "0 (0%)"
         
-        # ARCHIVE
-        # missing_count = len(folder_data['missing'])
-        # missing_percent = f"{missing_count}" #({missing_count * 100 / total_icons:.1f}%)" if total_icons > 0 else "0 (0%)"
-
-        # missing_percent = f"{missing_count} ({missing_count * 100 / total_icons:.1f}%) ![Missing](https://dummyimage.com/4x12/{bar_colors['missing']}/000&text=+)"
-        missing_count = total_icons - total_brand_icons
-        # print(missing_count)
-        missing_percent = f"{total_icons - total_brand_icons} ({(missing_count * 100) / total_icons:.1f}%) ![Missing](https://dummyimage.com/4x12/{bar_colors['missing']}/000&text=+)"
+        # Calculate missing correctly based on icons in other sets
+        missing_count = len(folder_data['missing'])
+        missing_percent = f"{missing_count} ({missing_count * 100 / total_icons:.1f}%) ![Missing](https://dummyimage.com/4x12/{bar_colors['missing']}/000&text=+)" if total_icons > 0 else "0 (0%)"
         
         markdown += f"| {folder_name} | {len(folder_data['processed_names'])} | {folder_data['total']} | {all_equivalence_percent} | {some_equivalence_percent} | {unique_percent} | {missing_percent} |\n"
     

--- a/README.md
+++ b/README.md
@@ -27,28 +27,28 @@ Use Mística icons library in Figma!
 ## Equivalence status
 
 Vivo-New  
-<img src='https://dummyimage.com/4x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/105x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/6x8/59C2C9/000&text=+' alt='Unique'><img src='https://dummyimage.com/285x8/D1D5E4/000&text=+' alt='Missing'>
+<img src='https://dummyimage.com/12x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/266x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/16x8/59C2C9/000&text=+' alt='Unique'><img src='https://dummyimage.com/106x8/D1D5E4/000&text=+' alt='Missing'>
 
 Telefonica  
-<img src='https://dummyimage.com/4x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/105x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/291x8/D1D5E4/000&text=+' alt='Missing'>
+<img src='https://dummyimage.com/12x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/265x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/123x8/D1D5E4/000&text=+' alt='Missing'>
 
 O2-New  
-<img src='https://dummyimage.com/4x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/78x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/1x8/59C2C9/000&text=+' alt='Unique'><img src='https://dummyimage.com/317x8/D1D5E4/000&text=+' alt='Missing'>
+<img src='https://dummyimage.com/12x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/197x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/2x8/59C2C9/000&text=+' alt='Unique'><img src='https://dummyimage.com/189x8/D1D5E4/000&text=+' alt='Missing'>
 
 O2  
-<img src='https://dummyimage.com/4x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/76x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/320x8/D1D5E4/000&text=+' alt='Missing'>
+<img src='https://dummyimage.com/12x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/194x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/194x8/D1D5E4/000&text=+' alt='Missing'>
 
 Blau  
-<img src='https://dummyimage.com/4x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/1x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/1x8/59C2C9/000&text=+' alt='Unique'><img src='https://dummyimage.com/394x8/D1D5E4/000&text=+' alt='Missing'>
+<img src='https://dummyimage.com/12x8/0066FF/000&text=+' alt='All Equivalence'><img src='https://dummyimage.com/5x8/EAC344/000&text=+' alt='Some Equivalence'><img src='https://dummyimage.com/1x8/59C2C9/000&text=+' alt='Unique'><img src='https://dummyimage.com/382x8/D1D5E4/000&text=+' alt='Missing'>
 
   
 | <sub><sup>ICON SET</sup></sub> | <sub><sup>CONCEPTS (624)</sup></sub> | <sub><sup>TOTAL (4494)</sup></sub> | <sub><sup>ALL EQUIVALENCE</sup></sub> | <sub><sup>SOME EQUIVALENCE</sup></sub> | <sub><sup>UNIQUE</sup></sub> | <sub><sup>MISSING</sup></sub> |
 | :--------- | --------: | -----: | ----------: | -------------------: | -------------------: | ------------: |
-| Vivo-New | 470 | 1312 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 1187 (26.4%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 70 (1.6%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 3182 (70.8%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
-| Telefonica | 433 | 1236 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 1181 (26.3%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 0 (0.0%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 3258 (72.5%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
-| O2-New | 318 | 941 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 879 (19.6%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 7 (0.2%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 3553 (79.1%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
-| O2 | 314 | 924 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 865 (19.2%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 0 (0.0%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 3570 (79.4%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
-| Blau | 64 | 81 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 21 (0.5%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 5 (0.1%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 4413 (98.2%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
+| Vivo-New | 470 | 1312 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 1187 (26.4%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 70 (1.6%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 472 (10.5%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
+| Telefonica | 433 | 1236 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 1181 (26.3%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 0 (0.0%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 548 (12.2%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
+| O2-New | 318 | 941 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 879 (19.6%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 7 (0.2%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 843 (18.8%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
+| O2 | 314 | 924 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 865 (19.2%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 0 (0.0%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 864 (19.2%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
+| Blau | 64 | 81 | 55 (1.2%) ![All Equivalence](https://dummyimage.com/4x12/0066FF/000&text=+) | 21 (0.5%) ![Some Equivalence](https://dummyimage.com/4x12/EAC344/000&text=+) | 5 (0.1%) ![Unique](https://dummyimage.com/4x12/59C2C9/000&text=+) | 1703 (37.9%) ![Missing](https://dummyimage.com/4x12/D1D5E4/000&text=+) |
 
 
 <sub>**Concepts**: Counts the different names of icons in the set excluding any variations in style or weight.</sub>  


### PR DESCRIPTION
### Pull Request Description: Improve Icons Calculation

This pull request enhances the icon calculation logic in the Markdown generator by accurately determining the missing icons based on the contents of other sets. The motivation behind this change is to ensure that the reports reflect a truthful representation of the icons available, specifically targeting the calculation of missing icons.

#### Key Improvements:
1. **Accurate Missing Icons Calculation**: 
   - The logic has been updated to correctly identify icons that are present in other sets but not in the current one. This change helps maintain an accurate overview of what icons are missing, improving the reliability of the data presented.

2. **Proportional Bar Width Calculation**: 
   - The calculation for the widths of the visual representations (bars) in the Markdown output has been adjusted to ensure that they are proportional to the total number of icons. This change prevents discrepancies that could arise from rounding errors, ensuring that the total width always matches the specified `bar_width`.

3. **Improved Readability in Output**:
   - The visual representation in the README has been updated to reflect the changes in the calculations, providing clearer insights into the equivalence status of icons across different sets.

By implementing these changes, we enhance the accuracy and clarity of the icon reports, which is crucial for users relying on this data for design consistency and completeness. This improvement ultimately contributes to the overall quality and usability of the icon library.