### PR TITLE
chore(GH Actions): Enable vivo export workflow

### DIFF
--- a/.github/scripts/figma-export/brands.config.js
+++ b/.github/scripts/figma-export/brands.config.js
@@ -71,33 +71,32 @@ const BRANDS = {
             },
         ],
     },
-    // todo https://github.com/Telefonica/mistica-design/issues/2689 Vivo brand is disabled for now until the next major version in mistica-web to avoid replacing the current vivo icons with the new default icon set, until new vivo icons set is ready.
-    // vivo: {
-    //     label: "Vivo",
-    //     figmaEnv: "VIVO_FIGMA_ID",
-    //     defaultFileId: "EApRpjaTyUOwW5VQU2ZqgP",
-    //     svgoTargets: ["icons/vivo"],
-    //     variants: [
-    //         {
-    //             configName: "vivo-filled.json",
-    //             frame: "Filled",
-    //             iconsPath: "icons/vivo/filled",
-    //             script: "export-vivo-filled",
-    //         },
-    //         {
-    //             configName: "vivo-regular.json",
-    //             frame: "Regular",
-    //             iconsPath: "icons/vivo/regular",
-    //             script: "export-vivo-regular",
-    //         },
-    //         {
-    //             configName: "vivo-light.json",
-    //             frame: "Light",
-    //             iconsPath: "icons/vivo/light",
-    //             script: "export-vivo-light",
-    //         },
-    //     ],
-    // },
+    vivo: {
+        label: "Vivo",
+        figmaEnv: "VIVO_FIGMA_ID",
+        defaultFileId: "EApRpjaTyUOwW5VQU2ZqgP",
+        svgoTargets: ["icons/vivo"],
+        variants: [
+            {
+                configName: "vivo-filled.json",
+                frame: "Filled",
+                iconsPath: "icons/vivo/filled",
+                script: "export-vivo-filled",
+            },
+            {
+                configName: "vivo-regular.json",
+                frame: "Regular",
+                iconsPath: "icons/vivo/regular",
+                script: "export-vivo-regular",
+            },
+            {
+                configName: "vivo-light.json",
+                frame: "Light",
+                iconsPath: "icons/vivo/light",
+                script: "export-vivo-light",
+            },
+        ],
+    },
     // todo https://github.com/Telefonica/mistica-design/issues/2689 Vivo brand is disabled for now until the next major version in mistica-web to avoid replacing the current vivo icons with the new default icon set, until new vivo icons set is ready.
     // "vivo-evolution": {
     //     label: "Vivo-evolution",


### PR DESCRIPTION
Enables the Vivo export workflow in our Figma export configuration. The Vivo brand was previously commented out due to concerns about potential conflicts with the current icon set in mistica-web. However, with this update, we are now ready to integrate the new Vivo icons.

By re-enabling the Vivo configuration, we can streamline our design export process and ensure that we are utilizing the latest assets for the Vivo brand. This change will improve our workflow efficiency and facilitate the upcoming updates to the Vivo icon set, aligning our design resources with the latest requirements.

Overall, this enhancement will enhance our design capabilities and maintain consistency across our projects.