### PR TITLE
feat(Figma CI): Include workflows for Mistica CI widget in Figma

### DIFF
--- a/.github/workflows-figma/mistica-icons-brands.yml
+++ b/.github/workflows-figma/mistica-icons-brands.yml
@@ -5,7 +5,7 @@
 #         "Default" / "O2" / "Vivo"                (brand variant, at least one)
 #           Instance "<name>-light" / "-regular" / "-filled" (live, style-suffixed)
 name: Mistica Icons · Brands Icons
-version: 1
+version: 1.0
 scope: page:"Brands Icons" # current-page | current-file | selection | page:"Name"
 
 steps:

--- a/.github/workflows-figma/mistica-icons-brands.yml
+++ b/.github/workflows-figma/mistica-icons-brands.yml
@@ -1,0 +1,105 @@
+# Expected structure, top to bottom:
+#   Page "Brands Icons"
+#     Frame "Light" / "Regular" / "Filled"        (top-level, exactly these three)
+#       Component ".<name>-light" / "-regular" / "-filled"   (private, style-suffixed)
+#         "Default" / "O2" / "Vivo"                (brand variant, at least one)
+#           Instance "<name>-light" / "-regular" / "-filled" (live, style-suffixed)
+name: Mistica Icons · Brands Icons
+version: 1
+scope: page:"Brands Icons" # current-page | current-file | selection | page:"Name"
+
+steps:
+  # 1. Exactly the three style frames must exist, top-level, no unexpected names
+  - uses: select
+    with:
+      types: [FRAME]
+      scope: top-level
+  - uses: assert.nameMatches
+    name: Frame naming
+    description: Every top-level frame on this page must be named "Light", "Regular" or "Filled".
+    severity: error
+    with: { pattern: "^(Light|Regular|Filled)$" }
+  - uses: assert.count
+    name: All three style frames present
+    description: The Light, Regular and Filled frames must all exist as top-level frames.
+    severity: error
+    with: { min: 3, max: 3 }
+
+  # 2. Only components live directly inside those frames, and they carry the style suffix
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children
+  - uses: assert.property
+    name: Only components in style frames
+    description: Everything directly inside the Light, Regular and Filled frames must be a Component.
+    severity: error
+    with: { property: type, equals: COMPONENT_SET }
+  - uses: assert.nameMatches
+    name: Icon component style suffix
+    description: Every component inside a style frame must end in -light, -regular or -filled.
+    severity: error
+    with: { pattern: "(-light|-regular|-filled)$" }
+
+  # 3. Those components must be private (name starts with ".")
+  - uses: assert.nameMatches
+    name: Icon component visibility
+    description: Every icon component must be private, i.e. its name must start with ".".
+    severity: error
+    with: { pattern: "^\\." }
+
+  # 4. Inside each icon component, at least one brand variant must exist.
+  # `assert.childCount` runs PER SELECTED NODE (each icon component's own
+  # children), unlike `assert.count`, which counts the whole flattened
+  # selection at once — that would miss one empty component if its siblings
+  # under other frames still had variants.
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children # icon components
+  - uses: assert.childCount
+    name: At least one brand variant
+    description: Every icon component must contain at least one brand variant.
+    severity: error
+    with: { min: 1 }
+  - uses: select.children # brand variants
+  - uses: assert.nameMatches
+    name: Brand variant naming
+    description: Every direct child of an icon component must be named "Default", "O2" or "Vivo".
+    severity: error
+    with:
+      {
+        pattern: "^(Brand=Default|Brand=O2|Brand=Vivo|Brand=Vivo Evolution|Brand=Blau)$",
+      }
+
+  # 5. Inside each brand variant, there must be a live instance.
+  # Same per-node reasoning as step 4: check each variant's own child count
+  # before flattening one more level down to the instances themselves.
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children # icon components
+  - uses: select.children # brand variants
+  - uses: assert.childCount
+    name: Brand variant contains an instance
+    description: Every brand variant must contain at least one node.
+    severity: error
+    with: { min: 1 }
+  - uses: select.children # the variant's contents
+  - uses: assert.isInstance
+    name: Instance is live
+    description: The node inside each brand variant must be a live component instance, not detached.
+    severity: error
+
+  # 6. That instance's name must carry the same style suffix
+  - uses: assert.nameMatches
+    name: Instance naming
+    description: The instance inside each brand variant must end in -light, -regular or -filled.
+    severity: error
+    with: { pattern: "(-light|-regular|-filled)$" }

--- a/.github/workflows-figma/mistica-icons-master.yml
+++ b/.github/workflows-figma/mistica-icons-master.yml
@@ -7,7 +7,7 @@
 #                                                     bound to a variable from the "iconSet"
 #                                                     variable collection)
 name: Mistica Icons · Master Icons
-version: 1
+version: 1.0
 scope: page:"Master Icons" # current-page | current-file | selection | page:"Name"
 
 steps:

--- a/.github/workflows-figma/mistica-icons-master.yml
+++ b/.github/workflows-figma/mistica-icons-master.yml
@@ -145,7 +145,7 @@ steps:
   - uses: assert.property
     name: Icon component description
     description: Every icon component must have its description field filled in. Select icons and use Mistica Icons Keywords plugin from Telefonica.
-    severity: error
+    severity: warning
     with: { property: description, notEquals: "" }
 
   # 9. Every icon component must also have at least one documentation link
@@ -159,7 +159,7 @@ steps:
   - uses: assert.property
     name: Icon component repo link
     description: Every icon component must have at least one repo link filled in. Select icons and use Mistica Icons Keywords plugin from Telefonica.
-    severity: error
+    severity: warning
     with:
       all:
         - { property: "documentationLinks.0.uri", exists: true }

--- a/.github/workflows-figma/mistica-icons-master.yml
+++ b/.github/workflows-figma/mistica-icons-master.yml
@@ -1,0 +1,166 @@
+# Expected structure, top to bottom:
+#   Page "Master Icons"
+#     Frame "Light" / "Regular" / "Filled"        (top-level, exactly these three)
+#       Component "<name>-light" / "-regular" / "-filled"   (NOT private, unlike Brands Icons)
+#         "Color"                                  (single child layer, locked)
+#           Instance                                (live; its exposed "Brand" property is
+#                                                     bound to a variable from the "iconSet"
+#                                                     variable collection)
+name: Mistica Icons · Master Icons
+version: 1
+scope: page:"Master Icons" # current-page | current-file | selection | page:"Name"
+
+steps:
+  # 1. Exactly the three style frames must exist, top-level, no unexpected names
+  - uses: select
+    with:
+      types: [FRAME]
+      scope: top-level
+  - uses: assert.nameMatches
+    name: Frame naming
+    description: Every top-level frame on this page must be named "Light", "Regular" or "Filled".
+    severity: error
+    with: { pattern: "^(Light|Regular|Filled)$" }
+  - uses: assert.count
+    name: All three style frames present
+    description: The Light, Regular and Filled frames must all exist as top-level frames.
+    severity: error
+    with: { min: 3, max: 3 }
+
+  # 2. Only components live directly inside those frames, and they carry the style suffix
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children # icon components
+  - uses: assert.property
+    name: Only components in style frames
+    description: Everything directly inside the Light, Regular and Filled frames must be a Component.
+    severity: error
+    with: { property: type, equals: COMPONENT }
+  - uses: assert.nameMatches
+    name: Icon component style suffix
+    description: Every component inside a style frame must end in -light, -regular or -filled.
+    severity: error
+    with: { pattern: "(-light|-regular|-filled)$" }
+
+  # 3. Unlike Brands Icons, these components must NOT be private, i.e. must NOT
+  # start with ".". `assert.nameMatches` only supports a positive regex, so a
+  # negative lookahead ("assert the next char isn't a dot") expresses "does
+  # not start with" — the dot must be escaped (\\.), otherwise it means "any
+  # character" instead of a literal dot.
+  - uses: assert.nameMatches
+    name: Icon component visibility
+    description: Every icon component must NOT be private, i.e. its name must not start with ".".
+    severity: error
+    with: { pattern: "^(?!\\.)" }
+
+  # 4. Layer structure inside each icon component. A normal icon has exactly one
+  # child layer named "Color"; a DEPRECATED icon additionally has a layer named
+  # "DeprecatedIcon" (a different internal structure). So each component must
+  # have one or two children, and every child must be named either "Color" or
+  # "DeprecatedIcon" — no stray layers.
+  #   - `assert.childCount` runs on the components (the current selection), so
+  #     it counts each component's OWN children.
+  #   - `select.children` then hops down to the child layers to name-check them.
+  - uses: assert.childCount
+    name: Icon component child count
+    description: Every icon component must contain one or two direct child layers.
+    severity: error
+    with: { min: 1, max: 2 }
+  - uses: select.children # the "Color" (and optional "DeprecatedIcon") layers
+  - uses: assert.nameMatches
+    name: Child layer naming
+    description: Each child layer must be named "Color" or, for deprecated icons, "DeprecatedIcon".
+    severity: error
+    with: { pattern: "^(Color|DeprecatedIcon)$" }
+
+  # 5. The remaining structural checks apply ONLY to the "Color" layer — the
+  # "DeprecatedIcon" layer has a different internal shape and is merely
+  # tolerated, not validated here. We re-select from the frames and use the new
+  # `select.children` name filter to isolate exactly the "Color" layers (cheap:
+  # it only walks each component's direct children, never the whole page).
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children # icon components
+  - uses: select.children # narrow to just the "Color" layer of each
+    with: { nameMatches: "^Color$" }
+  - uses: assert.property
+    name: Color layer is locked
+    description: The "Color" layer must be locked on canvas.
+    severity: error
+    with: { property: locked, equals: true }
+
+  # 6. Inside "Color" there must be a live instance (per-node reasoning: check
+  # the "Color" layer's own child count before flattening one level further down).
+  - uses: assert.childCount
+    name: Color layer contains an instance
+    description: The "Color" layer must contain at least one child node.
+    severity: error
+    with: { min: 1 }
+  - uses: select.children # the instance inside "Color"
+  - uses: assert.isInstance
+    name: Instance is live
+    description: The node inside "Color" must be a live component instance, not detached.
+    severity: error
+
+  # 7. That instance's "Brand" property must be bound to the variable named
+  # "iconSet" (not a raw/hardcoded value). "iconSet" is the VARIABLE name
+  # (full path "utils/iconSet"); `variable:` matches either the full path or
+  # its last segment. The variable happens to live in a collection named
+  # "Brand" — that's the collection, not the variable, so `collection:` would
+  # be the wrong check here. Re-select down to the "Color" layers and filter
+  # their children to those whose name starts with "." — the private brand
+  # instance's naming convention, same as Brands Icons — so a sibling like
+  # "DeprecatedIcon" (and anything inside it) is excluded here instead of
+  # also failing this variable-binding check.
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children # icon components
+  - uses: select.children # narrow to just the "Color" layer of each
+    with: { nameMatches: "^Color$" }
+  - uses: select.children # only the private brand instance inside "Color"
+    with: { nameMatches: "^\\." }
+  - uses: assert.variableBound
+    name: Instance brand variable
+    description: The instance's "Brand" property must be bound to the "iconSet" variable.
+    severity: error
+    with: { property: Brand, variable: iconSet }
+
+  # 8. Every icon component must document itself: a non-empty description,
+  # for library consumers browsing the file/plugin.
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children # icon components
+  - uses: assert.property
+    name: Icon component description
+    description: Every icon component must have its description field filled in. Select icons and use Mistica Icons Keywords plugin from Telefonica.
+    severity: error
+    with: { property: description, notEquals: "" }
+
+  # 9. Every icon component must also have at least one documentation link
+  # filled in (e.g. pointing at the mistica-icons GitHub repo).
+  - uses: select
+    with:
+      types: [FRAME]
+      nameMatches: "^(Light|Regular|Filled)$"
+      scope: top-level
+  - uses: select.children # icon components
+  - uses: assert.property
+    name: Icon component repo link
+    description: Every icon component must have at least one repo link filled in. Select icons and use Mistica Icons Keywords plugin from Telefonica.
+    severity: error
+    with:
+      all:
+        - { property: "documentationLinks.0.uri", exists: true }
+        - { property: "documentationLinks.0.uri", notEquals: "" }

--- a/.github/workflows-figma/skin-icons.yml
+++ b/.github/workflows-figma/skin-icons.yml
@@ -1,9 +1,22 @@
-# Checks apply only to components whose name ends in -regular, -filled or -light.
+# Expected structure, top to bottom:
+#   Page "Icons"
+#     Frame "Light" / "Regular" / "Filled"        (top-level; not all three need
+#                                                   to exist, but no other name
+#                                                   is allowed)
+#       Component "<name>-light" / "-regular" / "-filled"   (24x24, unique name,
+#                                                             anywhere on the page)
+#         "icon"                                  (single child layer, flattened
+#                                                   VECTOR, solid black fill, no
+#                                                   bound variable, NONZERO winding
+#                                                   rule, SCALE constraints)
 name: Brand set icon validation
-version: 1
+version: 1.0
 scope: page:"Icons" # current-page | current-file | selection | page:"Name"
 
 steps:
+  # 1. If any top-level frames exist, they must be named "Light", "Regular" or
+  # "Filled" — unlike Master/Brands Icons, not all three are required here,
+  # only that no other frame name is allowed.
   - uses: select
     with:
       types: [FRAME]
@@ -14,6 +27,8 @@ steps:
     severity: error
     with: { pattern: "^(Light|Regular|Filled)$" }
 
+  # 2. Only components live directly inside those (optional) style frames — no
+  # stray instances, groups, or un-componentised frames.
   - uses: select
     with:
       types: [FRAME]
@@ -26,6 +41,10 @@ steps:
     severity: error
     with: { property: type, equals: COMPONENT }
 
+  # 3. Re-select more broadly (`scope: descendants`, no frame restriction):
+  # every component anywhere on the page — not just inside a style frame —
+  # must carry the style suffix, so downstream tooling can identify its
+  # variant regardless of where it lives.
   - uses: select
     with:
       types: [COMPONENT]
@@ -36,6 +55,7 @@ steps:
     severity: error
     with: { pattern: "(-regular|-filled|-light)$" }
 
+  # 4. Same page-wide selection: every icon component must be exactly 24x24.
   - uses: select
     with:
       types: [COMPONENT]
@@ -49,11 +69,19 @@ steps:
         - { property: width, equals: 24 }
         - { property: height, equals: 24 }
 
+  # 5. No two icon components anywhere on the page may share the exact same
+  # name — this asserts against the whole page, not per-node, since it is
+  # comparing siblings against each other rather than checking one node in
+  # isolation.
   - uses: assert.uniqueName
     name: No duplicate icon names
     description: No two icon components may share the exact same name. A duplicate usually means an accidental copy-paste that was never renamed.
     severity: error
 
+  # 6. From here on, checks apply only to the icon's inner vector layer.
+  # Narrow the selection to components that already carry the style suffix
+  # (excludes anything stray/unfinished still failing step 3) and hop down to
+  # their single child layer.
   - uses: select
     with:
       types: [COMPONENT]
@@ -66,6 +94,8 @@ steps:
     severity: error
     with: { property: windingRule, notEquals: EVENODD }
 
+  # 7. That same inner layer must scale proportionally with the component,
+  # in both directions.
   - uses: select
     with:
       types: [COMPONENT]
@@ -81,6 +111,9 @@ steps:
         - { property: constraints.horizontal, equals: SCALE }
         - { property: constraints.vertical, equals: SCALE }
 
+  # 8. `assert.childCount` runs on the components (the current selection), so
+  # it counts each suffix-named icon component's OWN children — more than one
+  # usually means ungrouped or leftover shapes.
   - uses: select
     with:
       types: [COMPONENT]
@@ -92,6 +125,9 @@ steps:
     severity: error
     with: { equals: 1 }
 
+  # 9. That single child layer must be named exactly "icon" (re-select and hop
+  # down again, since step 8 needed the components themselves, not their
+  # children).
   - uses: select
     with:
       types: [COMPONENT]
@@ -104,6 +140,9 @@ steps:
     severity: error
     with: { pattern: "^icon$" }
 
+  # 10. The inner "icon" vector must have a solid black fill, with no
+  # variable/token bound to it — colour is applied elsewhere (e.g. via CSS or
+  # a wrapping component), so these vectors stay lightweight and skin-agnostic.
   - uses: select
     with:
       types: [COMPONENT]
@@ -122,6 +161,9 @@ steps:
         - { property: fills.0.color.b, equals: 0 }
         - { property: fills.0.boundVariables.color, exists: false }
 
+  # 11. Finally, that inner "icon" layer must be a single flattened vector —
+  # not a live boolean operation (union, subtract, intersect or exclude) that
+  # could still change shape if its constituent layers are edited.
   - uses: select
     with:
       types: [COMPONENT]

--- a/.github/workflows-figma/skin-icons.yml
+++ b/.github/workflows-figma/skin-icons.yml
@@ -1,0 +1,135 @@
+# Checks apply only to components whose name ends in -regular, -filled or -light.
+name: Brand set icon validation
+version: 1
+scope: page:"Icons" # current-page | current-file | selection | page:"Name"
+
+steps:
+  - uses: select
+    with:
+      types: [FRAME]
+      scope: top-level
+  - uses: assert.nameMatches
+    name: Icon style frames
+    description: Every top-level frame must be named "Light", "Regular" or "Filled". Not all three need to exist, but no other frame names are allowed.
+    severity: error
+    with: { pattern: "^(Light|Regular|Filled)$" }
+
+  - uses: select
+    with:
+      types: [FRAME]
+      scope: top-level
+      nameMatches: "^(Light|Regular|Filled)$"
+  - uses: select.children
+  - uses: assert.property
+    name: Only components in frames
+    description: Everything directly inside the Light, Regular and Filled frames must be a Component — no stray instances, groups, or un-componentised frames.
+    severity: error
+    with: { property: type, equals: COMPONENT }
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      scope: descendants
+  - uses: assert.nameMatches
+    name: Component naming
+    description: Every component must be named ending in -regular, -light or -filled, which marks its icon style variant.
+    severity: error
+    with: { pattern: "(-regular|-filled|-light)$" }
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      scope: descendants
+  - uses: assert.property
+    name: Icon size
+    description: Every icon component must be 24x24. If an icon that looks 24x24 still fails, its actual size is slightly off (sub-pixel) — Figma rounds the W/H it displays, so a value like 24.01 shows as "24".
+    severity: error
+    with:
+      all:
+        - { property: width, equals: 24 }
+        - { property: height, equals: 24 }
+
+  - uses: assert.uniqueName
+    name: No duplicate icon names
+    description: No two icon components may share the exact same name. A duplicate usually means an accidental copy-paste that was never renamed.
+    severity: error
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      nameMatches: "(-regular|-filled|-light)$"
+      scope: descendants
+  - uses: select.children
+  - uses: assert.property
+    name: Evenodd values
+    description: Icon vector layers must not use the EVENODD fill rule. Use NONZERO instead, so the shape does not clip or invert when the icon is scaled.
+    severity: error
+    with: { property: windingRule, notEquals: EVENODD }
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      nameMatches: "(-regular|-filled|-light)$"
+      scope: descendants
+  - uses: select.children
+  - uses: assert.property
+    name: Sizing
+    description: Icon layers must have both horizontal and vertical constraints set to SCALE, so the artwork resizes proportionally with the component.
+    severity: error
+    with:
+      all:
+        - { property: constraints.horizontal, equals: SCALE }
+        - { property: constraints.vertical, equals: SCALE }
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      nameMatches: "(-regular|-filled|-light)$"
+      scope: descendants
+  - uses: assert.childCount
+    name: Children layers
+    description: Each icon component must contain exactly one layer inside. More than one layer usually means ungrouped or leftover shapes.
+    severity: error
+    with: { equals: 1 }
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      nameMatches: "(-regular|-filled|-light)$"
+      scope: descendants
+  - uses: select.children
+  - uses: assert.nameMatches
+    name: Children layer name
+    description: The single inner layer of each icon must be named exactly "icon", so downstream tooling can find it reliably.
+    severity: error
+    with: { pattern: "^icon$" }
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      nameMatches: "(-regular|-filled|-light)$"
+      scope: descendants
+  - uses: select.children
+  - uses: assert.property
+    name: Icon fill color
+    description: The inner "icon" vector must have a solid black fill (#000000). Colour is applied elsewhere, so no variables/tokens are used here to keep icons lightweight.
+    severity: error
+    with:
+      all:
+        - { property: fills.0.type, equals: SOLID }
+        - { property: fills.0.color.r, equals: 0 }
+        - { property: fills.0.color.g, equals: 0 }
+        - { property: fills.0.color.b, equals: 0 }
+        - { property: fills.0.boundVariables.color, exists: false }
+
+  - uses: select
+    with:
+      types: [COMPONENT]
+      nameMatches: "(-regular|-filled|-light)$"
+      scope: descendants
+  - uses: select.children
+  - uses: assert.property
+    name: Flattened vector
+    description: The inner "icon" layer must be a single flattened vector (type VECTOR), not a live boolean operation (union, subtract, intersect or exclude).
+    severity: error
+    with: { property: type, equals: VECTOR }


### PR DESCRIPTION
Files including this workflows:
Mistica Icons
- https://www.figma.com/design/JHuzksh01yxExMeMQBvymq/M%C3%ADstica-Icons?node-id=0-71
- https://www.figma.com/design/JHuzksh01yxExMeMQBvymq/M%C3%ADstica-Icons?node-id=7809-530

Mistica Skin Libraries
- https://www.figma.com/design/JXy7Y07eb0Axg0ThVRWKju/Default-Icons-Set?node-id=0-71
- https://www.figma.com/design/sDxRJeu0D7OEX5FjJsORbu/Vivo-Evolution?node-id=0-1
- https://www.figma.com/design/EApRpjaTyUOwW5VQU2ZqgP/Vivo?node-id=2625-199
- https://www.figma.com/design/czemeClWRGBI8oF7caNa5m/Blau?node-id=603-3314
- https://www.figma.com/design/CjvgrHEIycSQ6exznxnFXT/O2?node-id=3962-2